### PR TITLE
added 'alt' page with groupings based around works

### DIFF
--- a/app/views/v20/assessment-pd-alt.html
+++ b/app/views/v20/assessment-pd-alt.html
@@ -1,0 +1,90 @@
+assessment-immunity.html
+{% extends "layout.html" %} {% block head %} {{ super() }}
+
+{% from "./customnjk/applications_table/not-started-app.njk"  import application_not_started %}
+{% from "./customnjk/applications_table/in-assessment-app.njk"  import application_in_assessment %}
+{% from "./customnjk/applications_table/awaiting-det-app.njk"  import application_awaiting_determination %}
+{% from "./customnjk/applications_table/closed-app.njk"  import application_closed %}
+{% from "./customnjk/application-info-alt.njk"  import applicationinfo %} 
+{% from "./customnjk/related-info.njk" import relatedinfo %} 
+{% from "./customnjk/header.njk" import header %}
+{% from "./customnjk/pd-assessment-table.njk" import pd %}
+
+
+<link href="/public/sass/southwark-branding.css" rel="stylesheet" type="text/css">
+
+{% endblock %}
+
+{% block content %}
+
+
+
+<! –– Header ––>
+<div>
+{{header(
+    "valid", "green",
+    "10 October 2021", 
+    "15 days remaining", "green"
+)}}
+</div>
+
+<div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-two-thirds">
+        <! –– Application detail blocks ––>
+        {{ applicationinfo() }}
+    
+  
+    <! -- Task List -->
+<div style="margin-top: 60px;">
+  <ol class="moj-task-list" style="margin-top: 30px;">
+    <li>
+      <h2 class="moj-task-list__section">
+      <span class="moj-task-list__section-number">Validation</span>
+      </h2>
+      <ul class="moj-task-list__items">
+        <li class="moj-task-list__item">
+          <a class="moj-task-list__task-name" href="validation-update.html">Validate application</a>
+            <strong class="govuk-tag govuk-tag--green" style="float: right;">
+            Valid
+            </strong>    
+        </li>
+      </ul>
+        <li>
+          <h2 class="moj-task-list__section">
+            <span class="moj-task-list__section-number">Assessment </span>
+          </h2>
+          {{pd(
+          data['history-check'], data['history-tag'],
+          data['summary-check'], data['summary-tag'],
+          data['submit-check'], data['submit-tag']
+          )}}
+        </li>
+       
+            <h2 class="moj-task-list__section">
+              <span class="moj-task-list__section-number">Recommendation</span>
+            </h2>
+            <ul class="moj-task-list__items">
+              <li class="moj-task-list__item">
+                <p>Review assessment</p>
+              </li>
+              <li class="moj-task-list__item">
+                <p>Publish determination</p>
+              </li>
+            </ul>
+          </li>
+      </ol>
+   
+   
+   
+
+  <! –– Right panel with additional information in accordion ––>
+</div>
+</div>
+ 
+<div class="govuk-grid-column-one-third">
+    {{ relatedinfo() }}
+  </div>
+
+</div>
+  {% endblock %}

--- a/app/views/v20/customnjk/application-info-alt.njk
+++ b/app/views/v20/customnjk/application-info-alt.njk
@@ -1,0 +1,394 @@
+{% macro applicationinfo(status, officer) %}
+{% block content %}
+
+
+
+<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+    <div class="govuk-accordion__section ">
+      <div class="govuk-accordion__section-header">
+        <h3 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+            Application information
+          </span>
+        </h3>
+        
+      </div>
+      <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+       <tbody class="govuk-table__body">
+        <table class="govuk-table">
+               <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><p class="govuk-body"> <a class="govuk-link govuk-link--no-visited-state" href="edit-details.html">Edit details</a></p></td>
+              <td class="govuk-table__cell">
+                
+                </td>
+           </tr>
+         
+            </tr>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><b>Description:</b></td>
+                <td class="govuk-table__cell">	Proposed two storey side extension, new front shed, floor plan redesign and all associated works at 1 Rycott Path.<p style="margin-top: 12px;"></td>
+            </tr>
+             <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><b>Application type: </b></td>
+                <td class="govuk-table__cell">FULL HOUS</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><b>Site address: </b></td>
+                <td class="govuk-table__cell">1 Rycott Path, London, SE22 0AA <p style="margin-top: 12px;"></td>
+            </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell"><b>Location: </b></td>
+                  <td class="govuk-table__cell">
+             <a href="https://www.google.com/maps/place/1+Rycott+Path,+East+Dulwich,+London+SE22+0AA/@51.4477935,-0.0743742,17z/data=!3m1!4b1!4m5!3m4!1s0x487603ea397f40f3:0xd69666d31fa5098e!8m2!3d51.4477935!4d-0.0721855" target="_blank">View site on Google Maps</a></td>
+            </tr>
+              <tr class="govuk-table__row">
+                  <td class="govuk-table__cell"><b>UPRN: </b></td>
+                  <td class="govuk-table__cell">	200003436472</td>
+            </tr>
+                     <tr class="govuk-table__row">
+                  <td class="govuk-table__cell"><b>Ward: </b></td>
+                  <td class="govuk-table__cell">Rye Lane</td>
+            </tr>
+                      
+             <tr class="govuk-table__row">
+                  <td class="govuk-table__cell"><b>Property type: </b></td>
+                  <td class="govuk-table__cell">Terrace</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><b>Payment reference: </b></td>
+                <td class="govuk-table__cell">H14 13E7 WMU</td>
+            </tr>
+          
+        </table>
+        </tbody>
+      </div>
+    </div>
+
+    <div class="govuk-accordion__section ">
+      <div class="govuk-accordion__section-header">
+        <h3 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+            Site map
+          </span>
+        </h3>
+      </div>
+      <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1" style="max-height:none;">
+        <p class='govuk-body'><a href="/public/images/FH_SITE_LOCATION_PLAN-857983.pdf" target="_blank">View site map in new window</a></p>
+                   
+                <img src="/public/images/FH_SITE_LOCATION_PLAN-857983.png" style="max-width: 600px; margin-bottom: 10px;" alt="map">
+
+      </div>
+    </div>
+     <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section-header">
+        <h3 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+            Proposal details
+          </span>
+        </h3>
+    </div>
+    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1" style="max-height:none;">  
+      <ul class="govuk-body"><strong> 
+        <li>
+          <a href="#summary-details">Summary details</a> 
+        </li>
+        <li> 
+          <a href="#typeofwork">Add a rear or side extension</a>
+        </li>
+        <li> 
+          <a href="#property">Property</a>
+        </li>
+        <li>
+          <a href="#applicant">Applicant</a>
+        </li>
+        <li> 
+          <a href="#application">Application and fee</a>
+        </li>
+      </strong></ul>
+      <h4 class="govuk-heading-s">
+        <a id="summary_details">Summary details</a>
+      </h4>
+      <ol class="govuk-body" style="line-height: 2;">
+           <li><strong>What are you applying about? </strong> </br>
+                Changes that will be made in the future </br>
+                Town and Country Planning Act 1990 Section 171B</br>
+           </li>
+           <li><strong>What do the works involve?</strong></br>
+                addition of a rear extension </br>
+           </li>
+           <li><strong>List all the changes involved in the project:</strong></br>
+                <a href="#typeofwork">Add a rear or side extension</a> </br>
+           </li>
+      </ol>
+      <h4 class="govuk-heading-s">
+        <a id="typeofwork">Add a rear or side extension (S.2 P.1, Part A)</a>
+      </h4>
+      <ol class="govuk-body" style="line-height: 2;"> 
+        <li><strong>Which of these best describes your project?</strong> </br>
+                Rear only</br>
+                General Permitted Development Order 2015, Technical guidance</br>
+        </li>
+        <li><strong>How much of the property is covered by extensions and outbuildings?</strong> </br>
+                50% or less of the available area around the original house</br>
+                General Permitted Development Order 2015 S.2 P.1 A.1 (b)</br>
+        </li>
+        <li><strong>How far does the new addition extend beyond the back wall of the original house?</strong> </br>
+                3m or less</br>
+                General Permitted Development Order 2015 S.2 P.1 A.1 (f)(i)</br>
+        </li>
+        <li><strong>What is the height of the extension?</strong> </br>
+                4m or less</br>
+                General Permitted Development Order 2015 S.2 P.1 A.1 (f)(ii)</br>
+        </li>
+        <li><strong>How many storeys does the extension have?</strong> </br>
+                One storey</br>
+                General Permitted Development Order 2015 S.2 P.1 A.1 (k)(i)</br>
+        </li>
+        <li><strong>Describe the materials and appearance of the extension</strong> </br>
+                Similar to the original house</br>
+                General Permitted Development Order 2015 S.2 P.1 A.3 (a)</br>
+        </li>
+        <li><strong>Does the extension include any rooflights?</strong></br>
+              Yes</br>
+          </li>
+          <li><strong>Does the extension include any new windows?</strong></br>
+              Yes</br>
+          </li>
+          <li><strong>What is the shortest distance to the property boundary?</strong></br>
+              2 metres or more</br>
+          </li>
+          <li><strong>Does the extension include any new external doors?</strong></br>
+              Yes</br>
+          </li>
+          <li><strong>What type of roof does the extension have?</strong></br>
+              Flat</br>
+          </li>
+          <li><strong>What is the purpose of the extension?</strong> </br>
+                To extend the home</br>
+                Town and Country Planning Act 1990, Section 55</br>
+          </li>
+          <li><strong>Will the works involve any alterations to ground levels?</strong></br>
+              No</br>
+          </li>
+      </ol>
+      <h4 class="govuk-heading-s" >
+        <a id="property"> Property </a>
+      </h4>
+        <ol class="govuk-body" style="line-height: 2;"> 
+          <li><strong>Was the house built before 2020?</strong></br>
+              Yes, it was built before 2020 </br>
+          </li>
+          <li><strong>How many storeys does the original house have?</strong> </br>
+              Two or more</br>
+          </li>
+          <li><strong>Does the original house have a projection to the rear?</strong> </br>
+              No</br>
+          </li>
+          <li><strong>Was the house always a house?</strong> </br>
+            Yes, it was built as a house </br>
+          </li>
+          <li><strong>What type of property is it?</strong> </br>
+            House</br>
+            General Permitted Development Order 2015
+          </li>
+          <li><strong>What type of house is it?</strong> </br>
+            Semi-detached</br>
+          </li>
+          <li><strong>The properties BLPU code is:</strong> </br>
+            RD</br>
+          </li>
+      </ol>
+      <h4 class="govuk-heading-s">
+        <a id="applicant"> Applicant </a>
+      </h4>
+      <ol class="govuk-body" style="line-height: 2;">
+           <li><strong>I am</strong> </br>
+                the applicant</br>
+           </li>
+           <li> <strong>Connections with Southwark Council</strong>  </br>
+              None of the above apply to me
+           </li>
+           <li><strong>I confirm that:</strong></br>
+                The information contained in this application is truthful, accurate and complete</br>
+           </li>
+           <li><strong>Title</strong></br>
+                Mr</br>
+           </li>
+           <li><strong>Is your contact address the same as the property address?</strong></br>
+                Yes</br>
+           </li>
+           <li><strong>I am applying</strong></br>
+                As a private individual</br>
+           </li>
+           <li><strong>Which of these best describes your interest in the land?</strong> </br>
+                Sole owner</br>
+                The Town and Country Planning (Development Management Procedure) (England) Order 2015</br>
+          </li>
+      </ol>
+      <h4 class="govuk-heading-s">
+        <a id="application"> Application and fee</a>
+      </h4>
+      <ol class="govuk-body" style="line-height: 2;">
+           <li><strong>Is this application a resubmission?</strong></br>
+                It is a test resubmission</br>
+                UK Statutory Instruments 2012 No. 2920 Regulation 8, UK Statutory Instruments 2012 No. 2920 Regulation 9
+           </li>
+           <li><strong>Does the application qualify for a resubmission exemption?</strong></br>
+                No</br>
+                UK Statutory Instruments 2012 No. 2920 Regulation 4
+           </li>
+           <li><strong>Are the works being carried out for the sole purpose of providing access for a disabled resident?</strong></br>
+                Yes</br>
+                <em>Auto-answered by RIPA</em>
+           </li>
+           <li><strong>Does the application qualify for a disability exemption?</strong></br>
+                No</br>
+                <em>Auto-answered by RIPA</em>
+           </li>
+           <li><strong>If a planning officer needs to make a site visit, who should they contact?</strong></br>
+                Me</br>
+           </li>
+           <li><strong>Do these floor plans show the entire property?</strong></br>
+                Yes</br>
+           </li>
+           <li><strong>How many homes does this application relate to?</strong> </br>
+                One</br>
+                The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Schedule 1, Part 2</br>
+          </li>
+        </ol>
+    </div>
+</div>
+  <div class="govuk-accordion__section ">
+      <div class="govuk-accordion__section-header">
+        <h3 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+            Documents
+          </span>
+        </h3>
+      </div>
+      <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1" style="max-height:none;">
+        <p><a class="govuk-link govuk-link--no-visited-state" href="pd-drawing-numbers.html">View documents</a></p>
+        <ul class="app-task-list">
+          <li class="app-task-list__item">
+            <div class="govuk-grid-column-one-quarter">
+
+            <p>  <div class="govuk-!-padding-bottom-0.5"></div>
+              <img src="/public/images/EXISTING_GROUND_FLOOR_PLAN-848007.png" style="width: 75px; border: solid 1px #eeeeee"/>
+              </p>
+
+              <p>
+                  <p>
+                <a href="/public/images/EXISTING_GROUND_FLOOR_PLAN-848007.pdf" target="_blank" >View PDF in new window</a>
+              </p>
+              </p>
+            </div>
+            <div  class="govuk-grid-column-three-quarter">
+              <p>
+              <div class="govuk-!-padding-bottom-0.5"></div>
+                <strong class="govuk-tag govuk-tag--turquoise">FLOOR</strong> 
+                 <strong class="govuk-tag govuk-tag--turquoise">PLAN</strong> 
+                 <strong class="govuk-tag govuk-tag--turquoise">PROPOSED</strong>
+                </p>
+                <p>
+                File name: 10390-Proposed-ground-floorplan.PDF<br/>
+                Date received: 02 January 2021<br/>
+                Document reference(s): 243646HF<br/>
+                Included on decsion notice: Yes<br/>
+                Public: No
+            
+              </p>
+            </div>
+            
+
+          </li>
+
+          <li class="app-task-list__item">
+            <div class="govuk-grid-column-one-quarter">
+             <p>
+            <div class="govuk-!-padding-bottom-0.5"></div>
+              <img src="/public/images/PROPOSED_REAR_ELEVATION-848012.png" style="width: 75px; border: solid 1px #eeeeee"/>
+              </p>
+              <p>
+                <a href="/public/images/PROPOSED_REAR_ELEVATION-848012.pdf" target="_blank" >View PDF in new window</a>
+              </p>
+            </div>
+            <div class="govuk-grid-column-three-quarter">
+               <p>
+                 <div class="govuk-!-padding-bottom-0.5"></div>
+                <strong class="govuk-tag govuk-tag--turquoise">REAR</strong> 
+                 <strong class="govuk-tag govuk-tag--turquoise">ELEVATION</strong> 
+                 <strong class="govuk-tag govuk-tag--turquoise">PROPOSED</strong>
+                </p>
+                <p>
+                File name: PROPOSED_REAR_ELEVATION-848012.pdf<br/>
+                Date received: 02 January 2021<br/>
+                Document reference(s): 243646HF<br/>
+                Included on decsion notice: No<br/>
+    
+              </p>
+            </div>
+            
+          </li>
+
+          <li class="app-task-list__item">
+            <div class="govuk-grid-column-one-quarter">
+            <p>
+            <div class="govuk-!-padding-bottom-0.5"></div>
+              <img src="/public/images/PROPOSED_ROOF_PLAN-848010.png" style="width: 75px; border: solid 1px #eeeeee"/>
+              </p>
+              <p>
+                <a href="/public/images/10395-Proposed-roof-plan.PDF" target="_blank" >View PDF in new window</a>
+              </p>
+            </div>
+            <div class="govuk-grid-column-three-quarter">
+            <p>
+         
+        <div class="govuk-!-padding-bottom-0.5">
+            </p>
+        
+              <p>
+        
+               File name: 10395-Proposed-roof-plan.PDF<br>
+                Date received: 02 January 2021<br>
+            
+              </p>
+              </div>
+            </div>
+            
+          </li>
+
+          <li class="app-task-list__item">
+            <div class="govuk-grid-column-one-quarter">
+              <p>
+            <div class="govuk-!-padding-bottom-0.5"></div>
+              <img src="/public/images/PROPOSED_SIDE_ELEVATION-848013.png" style="width: 75px; border: solid 1px #eeeeee"/>
+              </p>
+              <p>
+              </p>
+              <p>
+                <a href="/public/images/PROPOSED_SIDE_ELEVATION-848013.pdf" target="_blank" >View PDF in new window</a>
+              </p>
+            </div>
+            <div class="govuk-grid-column-three-quarter">
+
+      
+ <div class="govuk-!-padding-bottom-1"></div>
+            
+              <p>
+           File name: PROPOSED_SIDE_ELEVATION-848013.pdf <br>
+                Date received: 02 Januray 2021<br/>
+  
+              </p>
+      
+            </div>
+            
+        </ul>
+     </div>
+    </div>
+    
+ 
+</div>
+
+{% endblock %}
+
+{% endmacro %}


### PR DESCRIPTION
https://trello.com/c/VFDVGdtM
This is part of a proposal for how to group proposal details. 

This example (...-alt) follows these rules

- Summary with selected questions
- No auto answered by RIPA questions are shown (duplicates except for the constraints and maybe fee information)
- All works listed in the works question have their own section and then are shown with ref to the section of GPDO
- Property 
- Applicant
- Application and Fee
